### PR TITLE
C bindings for the Rust library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,13 @@ documentation = "https://docs.rs/biscuit-auth"
 homepage = "https://github.com/clevercloud/biscuit"
 repository = "https://github.com/clevercloud/biscuit-rust"
 
+#[lib]
+#name = "biscuit_auth"
+
+[features]
+default = []
+capi = ["rand"]
+
 [dependencies]
 rand_core = "^0.5"
 sha2 = "^0.9"
@@ -24,9 +31,13 @@ chrono = "0.4"
 hex = "0.4"
 zeroize = { version = "1", default-features = false }
 thiserror = "1"
-
-#[build-dependencies]
-#prost-build = "0.6"
+rand = { version = "0.7", optional = true }
+inline-c = "0.1"
 
 [dev-dependencies]
 rand = "0.7"
+
+[package.metadata.capi.library]
+# Used as the library name and defaults to the crate name. This might get
+# prefixed with `lib` depending on the target platform.
+name = "biscuit_auth"

--- a/README.md
+++ b/README.md
@@ -178,6 +178,22 @@ They can be used for pretty printing of a fact or rule. As an example, with a ta
 
 biscuit implementations come with a default symbol table to avoid transmitting frequent values with every token.
 
+# C bindings
+
+This project can generate C bindings with [cargo-c](https://crates.io/crates/cargo-c)].
+
+compile it with:
+
+```
+cargo cinstall --prefix=/usr --destdir=./build
+```
+
+Run C integration tests with:
+
+```
+cargo ctest
+```
+
 ## License
 
 Licensed under Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -1,0 +1,26 @@
+language = "C"
+
+# Options for wrapping the contents of the header:
+
+# An optional string of text to output at the beginning of the generated file
+# default: doesn't emit anything
+header = '''/*
+ * Copyright 2020 Clever Cloud
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */'''
+
+# An optional name to use as an include guard
+# default: doesn't emit an include guard
+include_guard = "biscuit_bindings_h"
+

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -1,0 +1,552 @@
+use rand::prelude::*;
+use std::{
+    fmt,
+    ffi::{CStr, CString},
+    os::raw::c_char,
+    cell::RefCell,
+};
+
+enum Error {
+    Biscuit(crate::error::Token),
+    InvalidArgument,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::InvalidArgument => write!(f, "invalid argument"),
+            Error::Biscuit(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+
+thread_local! {
+    static LAST_ERROR: RefCell<Option<Error>> = RefCell::new(None);
+}
+
+fn update_last_error(err: Error) {
+    LAST_ERROR.with(|prev| {
+        *prev.borrow_mut() = Some(err);
+    });
+}
+
+#[no_mangle]
+pub extern fn error_message() -> *const c_char {
+    thread_local! {
+        static LAST: RefCell<Option<CString>> = RefCell::new(None);
+    }
+    LAST_ERROR.with(|prev| {
+        match *prev.borrow() {
+            Some(ref err) => {
+                let err = CString::new(err.to_string()).ok();
+                LAST.with(|ret| {
+                    *ret.borrow_mut() = err;
+                    ret.borrow().as_ref().map(|x| x.as_ptr()).unwrap_or(std::ptr::null())
+                })
+            },
+            None => std::ptr::null(),
+        }
+    })
+}
+
+pub struct Biscuit(crate::token::Biscuit);
+pub struct KeyPair(crate::crypto::KeyPair);
+pub struct PublicKey(crate::crypto::PublicKey);
+pub struct BiscuitBuilder<'a>(crate::token::builder::BiscuitBuilder<'a>);
+pub struct BlockBuilder(crate::token::builder::BlockBuilder);
+pub struct Verifier<'a>(crate::token::verifier::Verifier<'a>);
+
+#[repr(C)]
+pub struct Slice {
+    ptr: *const u8,
+    len: usize,
+}
+
+#[repr(C)]
+pub struct Bytes {
+    ptr: *mut u8,
+    len: usize,
+    capacity: usize,
+}
+
+impl Slice {
+    fn to_slice(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn keypair_new<'a>(
+    seed: Slice,
+) -> Option<Box<KeyPair>> {
+    let slice = seed.to_slice();
+    if slice.len() != 32 {
+        update_last_error(Error::InvalidArgument);
+        return None;
+    }
+
+    let mut seed = [0u8; 32];
+    seed.copy_from_slice(slice);
+
+    let mut rng: StdRng = SeedableRng::from_seed(seed);
+
+    Some(Box::new(KeyPair(crate::crypto::KeyPair::new(&mut rng))))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn keypair_public(
+    kp: Option<&KeyPair>,
+) -> Option<Box<PublicKey>> {
+    if kp.is_none() {
+        update_last_error(Error::InvalidArgument);
+    }
+    let  kp = kp?;
+
+    Some(Box::new(PublicKey((*kp).0.public())))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn keypair_free(
+    _kp: Option<Box<KeyPair>>,
+) {
+
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn public_key_free(
+    _kp: Option<Box<PublicKey>>,
+) {
+}
+
+
+#[no_mangle]
+pub unsafe extern "C" fn biscuit_builder<'a>(
+    keypair: Option<&'a KeyPair>,
+) -> Option<Box<BiscuitBuilder<'a>>> {
+    if keypair.is_none() {
+        update_last_error(Error::InvalidArgument);
+    }
+    let keypair = keypair?;
+
+    Some(Box::new(BiscuitBuilder(
+        crate::token::Biscuit::builder(&keypair.0),
+    )))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn biscuit_builder_add_authority_fact<'a>(
+    builder: Option<&mut BiscuitBuilder<'a>>,
+    fact: *const c_char,
+) -> bool {
+    if builder.is_none() {
+        update_last_error(Error::InvalidArgument);
+        return false;
+    }
+    let builder = builder.unwrap();
+
+    let fact = CStr::from_ptr(fact);
+    let s = fact.to_str();
+    if s.is_err() {
+        update_last_error(Error::InvalidArgument);
+        return false;
+    }
+
+    builder.0.add_authority_fact(s.unwrap()).is_ok()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn biscuit_builder_add_authority_rule<'a>(
+    builder: Option<&mut BiscuitBuilder<'a>>,
+    rule: *const c_char,
+) -> bool {
+    if builder.is_none() {
+        update_last_error(Error::InvalidArgument);
+        return false;
+    }
+    let builder = builder.unwrap();
+
+    let rule = CStr::from_ptr(rule);
+    let s = rule.to_str();
+    if s.is_err() {
+        update_last_error(Error::InvalidArgument);
+        return false;
+    }
+
+    builder.0.add_authority_rule(s.unwrap()).is_ok()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn biscuit_builder_add_authority_caveat<'a>(
+    builder: Option<&mut BiscuitBuilder<'a>>,
+    caveat: *const c_char,
+) -> bool {
+    if builder.is_none() {
+        update_last_error(Error::InvalidArgument);
+        return false;
+    }
+    let builder = builder.unwrap();
+
+    let caveat = CStr::from_ptr(caveat);
+    let s = caveat.to_str();
+    if s.is_err() {
+        update_last_error(Error::InvalidArgument);
+        return false;
+    }
+
+    builder.0.add_authority_caveat(s.unwrap()).is_ok()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn biscuit_builder_build<'a>(
+    builder: Option<Box<BiscuitBuilder<'a>>>,
+    seed: Slice,
+) -> Option<Box<Biscuit>> {
+    if builder.is_none() {
+        update_last_error(Error::InvalidArgument);
+    }
+    let builder = builder?;
+
+    let slice = seed.to_slice();
+    if slice.len() != 32 {
+        return None;
+    }
+
+    let mut seed = [0u8; 32];
+    seed.copy_from_slice(slice);
+
+    println!("building token");
+    let mut rng: StdRng = SeedableRng::from_seed(seed);
+    (*builder).0.build(&mut rng).map(Biscuit).map(Box::new).ok()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn biscuit_builder_free<'a>(
+    _builder: Option<Box<BiscuitBuilder<'a>>>,
+) {
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn biscuit_from(
+    biscuit: Slice,
+) -> Option<Box<Biscuit>> {
+    let biscuit = biscuit.to_slice();
+
+    crate::token::Biscuit::from(biscuit).map(Biscuit).map(Box::new).ok()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn biscuit_from_sealed(
+    biscuit: Slice,
+    secret: Slice,
+) -> Option<Box<Biscuit>> {
+    let biscuit = biscuit.to_slice();
+    let secret = secret.to_slice();
+
+    crate::token::Biscuit::from_sealed(biscuit, secret).map(Biscuit).map(Box::new).ok()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn biscuit_serialize(
+    biscuit: Option<&Biscuit>,
+) -> Bytes {
+    if biscuit.is_none() {
+        update_last_error(Error::InvalidArgument);
+        return Bytes {
+            ptr: std::ptr::null_mut(),
+            len: 0,
+            capacity: 0,
+        };
+    }
+
+    let biscuit = biscuit.unwrap();
+
+    (*biscuit).0.to_vec().map(|mut v| {
+        let res = Bytes {
+            ptr: v.as_mut_ptr(),
+            len: v.len(),
+            capacity: v.capacity(),
+        };
+
+        std::mem::forget(v);
+        res
+    }).unwrap_or_else(|e| {
+        update_last_error(Error::Biscuit(e));
+        Bytes {
+            ptr: std::ptr::null_mut(),
+            len: 0,
+            capacity: 0,
+        }
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn biscuit_serialize_sealed(
+    biscuit: Option<&Biscuit>,
+    secret: Slice,
+) -> Bytes {
+    if biscuit.is_none() {
+        update_last_error(Error::InvalidArgument);
+        return Bytes {
+            ptr: std::ptr::null_mut(),
+            len: 0,
+            capacity: 0,
+        };
+    }
+
+    let biscuit = biscuit.unwrap();
+    let secret = secret.to_slice();
+
+    (*biscuit).0.seal(secret).map(|mut v| {
+        let res = Bytes {
+            ptr: v.as_mut_ptr(),
+            len: v.len(),
+            capacity: v.capacity(),
+        };
+
+        std::mem::forget(v);
+        res
+    }).unwrap_or_else(|e| {
+        update_last_error(Error::Biscuit(e));
+        Bytes {
+            ptr: std::ptr::null_mut(),
+            len: 0,
+            capacity: 0,
+        }
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn biscuit_create_block(
+    biscuit: Option<&Biscuit>,
+) -> Option<Box<BlockBuilder>> {
+    if biscuit.is_none() {
+        update_last_error(Error::InvalidArgument);
+    }
+    let biscuit = biscuit?;
+
+    Some(Box::new(BlockBuilder((biscuit.0.create_block()))))
+}
+
+
+#[no_mangle]
+pub unsafe extern "C" fn biscuit_verify<'a, 'b>(
+    biscuit: Option<&'a Biscuit>,
+    root: Option<&'b PublicKey>,
+) -> Option<Box<Verifier<'a>>> {
+    if biscuit.is_none() {
+        update_last_error(Error::InvalidArgument);
+    }
+    let biscuit = biscuit?;
+    if root.is_none() {
+        update_last_error(Error::InvalidArgument);
+    }
+    let root = root?;
+
+    (*biscuit).0.verify((*root).0).map(Verifier).map(Box::new).ok()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn biscuit_free(
+    _biscuit: Option<Box<Biscuit>>,
+) {
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn block_builder_add_fact(
+    builder: Option<&mut BlockBuilder>,
+    fact: *const c_char,
+) -> bool {
+    if builder.is_none() {
+        update_last_error(Error::InvalidArgument);
+        return false;
+    }
+    let builder = builder.unwrap();
+
+    let fact = CStr::from_ptr(fact);
+    let s = fact.to_str();
+    if s.is_err() {
+        update_last_error(Error::InvalidArgument);
+        return false;
+    }
+
+    builder.0.add_fact(s.unwrap()).is_ok()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn block_builder_add_rule(
+    builder: Option<&mut BlockBuilder>,
+    rule: *const c_char,
+) -> bool {
+    if builder.is_none() {
+        update_last_error(Error::InvalidArgument);
+        return false;
+    }
+    let builder = builder.unwrap();
+
+    let rule = CStr::from_ptr(rule);
+    let s = rule.to_str();
+    if s.is_err() {
+        update_last_error(Error::InvalidArgument);
+        return false;
+    }
+
+    builder.0.add_rule(s.unwrap()).is_ok()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn block_builder_add_caveat(
+    builder: Option<&mut BlockBuilder>,
+    caveat: *const c_char,
+) -> bool {
+    if builder.is_none() {
+        update_last_error(Error::InvalidArgument);
+        return false;
+    }
+    let builder = builder.unwrap();
+
+    let caveat = CStr::from_ptr(caveat);
+    let s = caveat.to_str();
+    if s.is_err() {
+        update_last_error(Error::InvalidArgument);
+        return false;
+    }
+
+    builder.0.add_caveat(s.unwrap()).is_ok()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn block_builder_free(
+    _builder: Option<Box<BlockBuilder>>,
+) {
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn verifier_add_fact(
+    verifier: Option<&mut Verifier>,
+    fact: *const c_char,
+) -> bool {
+    if verifier.is_none() {
+        update_last_error(Error::InvalidArgument);
+        return false;
+    }
+    let verifier = verifier.unwrap();
+
+    let fact = CStr::from_ptr(fact);
+    let s = fact.to_str();
+    if s.is_err() {
+        update_last_error(Error::InvalidArgument);
+        return false;
+    }
+
+    verifier.0.add_fact(s.unwrap()).is_ok()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn verifier_add_rule(
+    verifier: Option<&mut Verifier>,
+    rule: *const c_char,
+) -> bool {
+    if verifier.is_none() {
+        update_last_error(Error::InvalidArgument);
+        return false;
+    }
+    let verifier = verifier.unwrap();
+
+    let rule = CStr::from_ptr(rule);
+    let s = rule.to_str();
+    if s.is_err() {
+        update_last_error(Error::InvalidArgument);
+        return false;
+    }
+
+    verifier.0.add_rule(s.unwrap()).is_ok()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn verifier_add_caveat(
+    verifier: Option<&mut Verifier>,
+    caveat: *const c_char,
+) -> bool {
+    if verifier.is_none() {
+        update_last_error(Error::InvalidArgument);
+        return false;
+    }
+    let verifier = verifier.unwrap();
+
+    let caveat = CStr::from_ptr(caveat);
+    let s = caveat.to_str();
+    if s.is_err() {
+        update_last_error(Error::InvalidArgument);
+        return false;
+    }
+
+    verifier.0.add_caveat(s.unwrap())
+        .map_err(|e| {
+            update_last_error(Error::Biscuit(e));
+        })
+        .is_ok()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn verifier_verify(
+    verifier: Option<&mut Verifier>,
+) -> bool {
+    if verifier.is_none() {
+        update_last_error(Error::InvalidArgument);
+        return false;
+    }
+    let verifier = verifier.unwrap();
+
+    match verifier.0.verify() {
+        Ok(()) => true,
+        Err(e) => {
+            update_last_error(Error::Biscuit(e));
+            false
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn verifier_print(
+    verifier: Option<&mut Verifier>,
+) -> *mut c_char {
+    if verifier.is_none() {
+        update_last_error(Error::InvalidArgument);
+        return std::ptr::null_mut();
+    }
+    let verifier = verifier.unwrap();
+
+    match CString::new(verifier.0.print_world()) {
+        Ok(s) => s.into_raw(),
+        Err(_) => {
+            update_last_error(Error::InvalidArgument);
+            return std::ptr::null_mut();
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn verifier_free<'a>(
+    _verifier: Option<Box<Verifier<'a>>>,
+) {
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bytes_free(
+    bytes: Bytes,
+) {
+    if bytes.ptr != std::ptr::null_mut() {
+        let _v = Vec::from_raw_parts(bytes.ptr, bytes.len, bytes.capacity);
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn string_free(
+  ptr: *mut c_char,
+) {
+    if ptr != std::ptr::null_mut() {
+        CString::from_raw(ptr);
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,3 +220,9 @@ pub mod error;
 pub mod format;
 pub mod token;
 pub mod parser;
+
+#[cfg(cargo_c)]
+mod capi;
+
+#[cfg(cargo_c)]
+pub use capi::*;

--- a/tests/capi.rs
+++ b/tests/capi.rs
@@ -1,0 +1,57 @@
+//#[cfg(test)]
+#[cfg(feature = "capi")]
+mod capi {
+    use inline_c::assert_c;
+
+    #[test]
+    fn build() {
+        (assert_c! {
+            #include <stdio.h>
+            #include <string.h>
+            #include "biscuit_auth.h"
+
+            int main() {
+                char *seed = "abcdefghabcdefghabcdefghabcdefgh";
+                Slice s;
+                s.ptr = (const uint8_t *) seed;
+                s.len = strlen(seed);
+
+                KeyPair * root_kp = keypair_new(s);
+                printf("keypair creation error? %s\n", error_message());
+                PublicKey* root = keypair_public(root_kp);
+
+                BiscuitBuilder* b = biscuit_builder(root_kp);
+                printf("builder creation error? %s\n", error_message());
+                biscuit_builder_add_authority_fact(b, "right(#authority, \"file1\", #read)");
+
+                printf("builder add authority error? %s\n", error_message());
+
+                Biscuit * biscuit = biscuit_builder_build(b, s);
+                printf("Hello, World!\n");
+                printf("biscuit creation error? %s\n", error_message());
+
+                Verifier * verifier = biscuit_verify(biscuit, root);
+                printf("verifier creation error? %s\n", error_message());
+                verifier_add_caveat(verifier, "*right(#abcd) <- right(#efgh)");
+                printf("verifier add caveat error? %s\n", error_message());
+                char* world_print = verifier_print(verifier);
+                printf("verifier world:\n%s\n", world_print);
+                string_free(world_print);
+                if(!verifier_verify(verifier)) {
+                    printf("verifier error: %s\n", error_message());
+                } else {
+                    printf("verifier succeeded\n");
+                }
+
+                verifier_free(verifier);
+                biscuit_free(biscuit);
+                public_key_free(root);
+                keypair_free(root_kp);
+
+                return 0;
+            }
+        })
+        .success()
+        .stdout("Hello world");
+    }
+}


### PR DESCRIPTION
this use the [cargo-c](https://github.com/lu-zero/cargo-c) crate to generate bindings, with static and dynamic library, pkgconfig file, and integrate unit tests.

This PR is waiting for [a cargo-c issue](https://github.com/lu-zero/cargo-c/issues/138) before merging