### PR TITLE
Parse dates in constraints after `<` and `>`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -181,12 +181,26 @@ fn constraint_kind(i: &str) -> IResult<&str, builder::ConstraintKind> {
     let (i, op) = delimited(space0, operator, space0)(i)?;
 
     match op {
-        Operator::Lower => map(parse_integer, |i| {
-            builder::ConstraintKind::Integer(datalog::IntConstraint::Lower(i))
-        })(i),
-        Operator::Larger => map(parse_integer, |i| {
-            builder::ConstraintKind::Integer(datalog::IntConstraint::Larger(i))
-        })(i),
+        Operator::Lower => alt((
+            map(parse_date, |d| {
+                builder::ConstraintKind::Date(builder::DateConstraint::Before(
+                    SystemTime::UNIX_EPOCH + Duration::from_secs(d),
+                ))
+            }),
+            map(parse_integer, |i| {
+                builder::ConstraintKind::Integer(datalog::IntConstraint::Lower(i))
+            }),
+        ))(i),
+        Operator::Larger => alt((
+            map(parse_date, |d| {
+                builder::ConstraintKind::Date(builder::DateConstraint::After(
+                    SystemTime::UNIX_EPOCH + Duration::from_secs(d),
+                ))
+            }),
+            map(parse_integer, |i| {
+                builder::ConstraintKind::Integer(datalog::IntConstraint::Larger(i))
+            }),
+        ))(i),
         Operator::LowerOrEqual => alt((
             map(parse_date, |d| {
                 builder::ConstraintKind::Date(builder::DateConstraint::Before(


### PR DESCRIPTION
Dates were only supported after `>=` and `<=`. Parsing did not fail,
it just parsed the year as an integer, so this gave unexepected results.

Since dates don't have `StrictAfter` nor `StrictBefore`, I just kept `After` and `Before`, which is not super satisfying.
Another solution would be to not allow dates after `<` and `>`, and to make the parsing fail, but I'm not sure about how to handle it (fwiw, i naturally used `<` for the TTL, using `<=` did not occur to me, and the spec uses `<` as well: https://github.com/CleverCloud/biscuit/blob/master/SPECIFICATIONS.md#constraints)