### PR TITLE
fix: compilation errors in bitvec / funty…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ zeroize = { version = "1", default-features = false }
 thiserror = "1"
 rand = { version = "0.7" }
 inline-c = { version = "0.1", optional = true }
+funty = "=1.1.0"
 
 [dev-dependencies]
 rand = "0.7"


### PR DESCRIPTION
It seems a transitive dependency of the project broke - bitvec - because
one of its own dependencies - funty - declared a global BITS const… hence breaking
the current project.

According to the bitvec project, a fix may be to force funty’s version
to 1.1.0.

The matching issue in bitvec :

https://github.com/bitvecto-rs/bitvec/issues/105