### PR TITLE
add examples of failing check parser

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1585,4 +1585,16 @@ mod tests {
             expected_policies
         );
     }
+
+    #[test]
+    fn complete_check_rule() {
+        use std::convert::TryInto;
+        fn test(rule: &str) {
+            let check: builder::Check = rule.try_into().unwrap();
+            assert_eq!(check.to_string(), rule.to_string());
+        }
+        test("check if resource(#ambient, \"foobar\") && operation(#ambient, #write)) || operation(#ambient, #read)");
+        test("check if resource(#ambient, \"foobar\"), operation(#ambient, #write)) or operation(#ambient, #read)");
+        test("check if resource(#ambient, \"foobar\") and operation(#ambient, #write)) or operation(#ambient, #read)");
+    }
 }


### PR DESCRIPTION
Currently the Check parser doesn't always consume all of its data and we end up with incomplete checks.

This adds three examples of failing parsing. Not sure if the three are relevant, but if we don't support those three, the ones we don't sure should throw a parsing error.