### PR TITLE
Fix typo in a parser error

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -39,7 +39,7 @@ pub fn fact(i: &str) -> IResult<&str, builder::Fact, Error> {
 
     let (i, _) = error(
         preceded(space0, eof),
-        |input| format!("unexpected trailigng data after fact: '{}'", input),
+        |input| format!("unexpected trailing data after fact: '{}'", input),
         " ,\n",
     )(i)?;
 


### PR DESCRIPTION
I was reading the biscuit code to learn a bit more about `nom` and found this typo. My OCD did the rest.