### PR TITLE
Make code easier to read

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -156,15 +156,7 @@ impl Token {
         next_key: &KeyPair,
         message: &[u8],
     ) -> Result<Self, error::Token> {
-        //FIXME: replace with SHA512 hashing
-        let mut to_sign = message.to_vec();
-        to_sign.extend(&next_key.public().to_bytes());
-        let signature = keypair
-            .kp
-            .try_sign(&to_sign)
-            .map_err(|s| s.to_string())
-            .map_err(error::Signature::InvalidSignatureGeneration)
-            .map_err(error::Format::Signature)?;
+        let signature = sign(&keypair, &next_key, &message)?;
 
         let block = Block {
             data: message.to_vec(),
@@ -189,15 +181,7 @@ impl Token {
             TokenNext::Secret(private) => KeyPair::from(private.clone()),
         };
 
-        //FIXME: replace with SHA512 hashing
-        let mut to_sign = message.to_vec();
-        to_sign.extend(&next_key.public().to_bytes());
-        let signature = keypair
-            .kp
-            .try_sign(&to_sign)
-            .map_err(|s| s.to_string())
-            .map_err(error::Signature::InvalidSignatureGeneration)
-            .map_err(error::Format::Signature)?;
+        let signature = sign(&keypair, &next_key, &message)?;
 
         let block = Block {
             data: message.to_vec(),

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -194,10 +194,7 @@ impl Token {
         next_key: &KeyPair,
         message: &[u8],
     ) -> Result<Self, error::Token> {
-        let keypair = match &self.next {
-            TokenNext::Seal(_) => return Err(error::Token::Sealed),
-            TokenNext::Secret(private) => KeyPair::from(private.clone()),
-        };
+        let keypair = self.next.keypair()?;
 
         let signature = sign(&keypair, &next_key, &message)?;
 
@@ -255,6 +252,17 @@ impl Token {
 
         Ok(())
     }
+}
+
+impl TokenNext {
+
+    pub fn keypair(&self) -> Result<KeyPair, error::Token> {
+        match &self {
+            TokenNext::Seal(_) => Err(error::Token::Sealed),
+            TokenNext::Secret(private) => Ok(KeyPair::from(private.clone())),
+        }
+    }
+
 }
 
 #[cfg(test)]

--- a/src/datalog/expression.rs
+++ b/src/datalog/expression.rs
@@ -27,7 +27,7 @@ impl Unary {
         match (self, value) {
             (Unary::Negate, ID::Bool(b)) => Some(ID::Bool(!b)),
             (Unary::Parens, i) => Some(i),
-            (Unary::Length, ID::Str(i)) => symbols.get_s(i).map(|s| ID::Integer(s.len() as i64)),
+            (Unary::Length, ID::Str(i)) => symbols.get_symbol(i).map(|s| ID::Integer(s.len() as i64)),
             (Unary::Length, ID::Bytes(s)) => Some(ID::Integer(s.len() as i64)),
             (Unary::Length, ID::Set(s)) => Some(ID::Integer(s.len() as i64)),
             _ => {
@@ -83,18 +83,18 @@ impl Binary {
 
             // string
             (Binary::Prefix, ID::Str(s), ID::Str(pref)) => {
-                match (symbols.get_s(s), symbols.get_s(pref)) {
+                match (symbols.get_symbol(s), symbols.get_symbol(pref)) {
                     (Some(s), Some(pref)) => Some(ID::Bool(s.starts_with(pref))),
                     _ => None,
                 }
             }
             (Binary::Suffix, ID::Str(s), ID::Str(suff)) => {
-                match (symbols.get_s(s), symbols.get_s(suff)) {
+                match (symbols.get_symbol(s), symbols.get_symbol(suff)) {
                     (Some(s), Some(suff)) => Some(ID::Bool(s.ends_with(suff))),
                     _ => None,
                 }
             }
-            (Binary::Regex, ID::Str(s), ID::Str(r)) => match (symbols.get_s(s), symbols.get_s(r)) {
+            (Binary::Regex, ID::Str(s), ID::Str(r)) => match (symbols.get_symbol(s), symbols.get_symbol(r)) {
                 (Some(s), Some(r)) => Some(ID::Bool(
                     Regex::new(&r).map(|re| re.is_match(&s)).unwrap_or(false),
                 )),

--- a/src/datalog/mod.rs
+++ b/src/datalog/mod.rs
@@ -5,7 +5,6 @@ use std::convert::AsRef;
 use std::fmt;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-pub type Symbol = u64;
 mod expression;
 mod symbol;
 pub use expression::*;
@@ -15,7 +14,7 @@ pub use symbol::*;
 pub enum ID {
     Variable(u32),
     Integer(i64),
-    Str(Symbol),
+    Str(SymbolIndex),
     Date(u64),
     Bytes(Vec<u8>),
     Bool(bool),
@@ -44,12 +43,12 @@ impl AsRef<ID> for ID {
 
 #[derive(Debug, Clone, PartialEq, Hash, Eq)]
 pub struct Predicate {
-    pub name: Symbol,
+    pub name: SymbolIndex,
     pub ids: Vec<ID>,
 }
 
 impl Predicate {
-    pub fn new(name: Symbol, ids: &[ID]) -> Predicate {
+    pub fn new(name: SymbolIndex, ids: &[ID]) -> Predicate {
         Predicate {
             name,
             ids: ids.to_vec(),
@@ -69,7 +68,7 @@ pub struct Fact {
 }
 
 impl Fact {
-    pub fn new(name: Symbol, ids: &[ID]) -> Fact {
+    pub fn new(name: SymbolIndex, ids: &[ID]) -> Fact {
         Fact {
             predicate: Predicate::new(name, ids),
         }
@@ -101,14 +100,9 @@ impl fmt::Display for Fact {
 }
 
 impl Rule {
-    pub fn apply<'a>(
-        &'a self,
-        facts: &'a HashSet<Fact>,
-        symbols: &'a SymbolTable,
-    ) -> impl Iterator<Item = Fact> + 'a {
-        // gather all of the variables used in that rule
-        let variables_set = self
-            .body
+    /// gather all of the variables used in that rule
+    fn variables_set(&self) -> HashSet<u32> {
+        self.body
             .iter()
             .flat_map(|pred| {
                 pred.ids.iter().filter_map(|id| match id {
@@ -116,16 +110,23 @@ impl Rule {
                     _ => None,
                 })
             })
-            .collect::<HashSet<_>>();
+            .collect::<HashSet<_>>()
+    }
 
+    pub fn apply<'a>(
+        &'a self,
+        facts: &'a HashSet<Fact>,
+        symbols: &'a SymbolTable,
+    ) -> impl Iterator<Item = Fact> + 'a {
         let head = self.head.clone();
-        let variables = MatchedVariables::new(variables_set);
+        let variables = MatchedVariables::new(self.variables_set());
+
         CombineIt::new(variables, &self.body, &self.expressions, facts, symbols).filter_map(move |h| {
             let mut p = head.clone();
             for index in 0..p.ids.len() {
-                let value = match &p.ids[index] {
+                match &p.ids[index] {
                     ID::Variable(i) => match h.get(i) {
-                      Some(val) => val,
+                      Some(val) => p.ids[index] = val.clone(),
                       None => {
                         println!("error: variables that appear in the head should appear in the body and constraints as well");
                         return None;
@@ -133,8 +134,6 @@ impl Rule {
                     },
                     _ => continue,
                 };
-
-                p.ids[index] = value.clone();
             }
 
             Some(Fact { predicate: p })
@@ -142,39 +141,7 @@ impl Rule {
     }
 
     pub fn find_match(&self, facts: &HashSet<Fact>, symbols: &SymbolTable) -> bool {
-        // gather all of the variables used in that rule
-        let variables_set = self
-            .body
-            .iter()
-            .flat_map(|pred| {
-                pred.ids.iter().filter_map(|id| match id {
-                    ID::Variable(i) => Some(*i),
-                    _ => None,
-                })
-            })
-            .collect::<HashSet<_>>();
-
-        let variables = MatchedVariables::new(variables_set);
-
-        let mut it = CombineIt::new(variables, &self.body, &self.expressions, facts, symbols).filter_map(|h| {
-            let mut p = self.head.clone();
-            for index in 0..p.ids.len() {
-                let value = match &p.ids[index] {
-                    ID::Variable(i) => match h.get(i) {
-                        Some(val) => val,
-                        None => {
-                            println!("error: variables that appear in the head should appear in the body and constraints as well");
-                            return None;
-                        }
-                    },
-                    _ => continue,
-                };
-
-                p.ids[index] = value.clone();
-            }
-
-            Some(Fact { predicate: p })
-        });
+        let mut it = self.apply(facts, symbols);
 
         let next = it.next();
         next.is_some()
@@ -380,7 +347,7 @@ impl MatchedVariables {
     }
 }
 
-pub fn fact<I: AsRef<ID>>(name: Symbol, ids: &[I]) -> Fact {
+pub fn fact<I: AsRef<ID>>(name: SymbolIndex, ids: &[I]) -> Fact {
     Fact {
         predicate: Predicate {
             name,
@@ -389,7 +356,7 @@ pub fn fact<I: AsRef<ID>>(name: Symbol, ids: &[I]) -> Fact {
     }
 }
 
-pub fn pred<I: AsRef<ID>>(name: Symbol, ids: &[I]) -> Predicate {
+pub fn pred<I: AsRef<ID>>(name: SymbolIndex, ids: &[I]) -> Predicate {
     Predicate {
         name,
         ids: ids.iter().map(|id| id.as_ref().clone()).collect(),
@@ -397,7 +364,7 @@ pub fn pred<I: AsRef<ID>>(name: Symbol, ids: &[I]) -> Predicate {
 }
 
 pub fn rule<I: AsRef<ID>, P: AsRef<Predicate>>(
-    head_name: Symbol,
+    head_name: SymbolIndex,
     head_ids: &[I],
     predicates: &[P],
 ) -> Rule {
@@ -409,7 +376,7 @@ pub fn rule<I: AsRef<ID>, P: AsRef<Predicate>>(
 }
 
 pub fn expressed_rule<I: AsRef<ID>, P: AsRef<Predicate>, C: AsRef<Expression>>(
-    head_name: Symbol,
+    head_name: SymbolIndex,
     head_ids: &[I],
     predicates: &[P],
     expressions: &[C],
@@ -806,8 +773,8 @@ mod tests {
         fn test_suffix(
             w: &World,
             syms: &mut SymbolTable,
-            suff: Symbol,
-            route: Symbol,
+            suff: SymbolIndex,
+            route: SymbolIndex,
             suffix: &str,
         ) -> Vec<Fact> {
             let id_suff = syms.add(suffix);
@@ -1090,8 +1057,6 @@ mod tests {
         let mut w = World::new();
         let mut syms = SymbolTable::new();
 
-        let authority = syms.add("authority");
-        let ambient = syms.add("ambient");
         let resource = syms.insert("resource");
         let operation = syms.insert("operation");
         let right = syms.insert("right");
@@ -1187,7 +1152,6 @@ mod tests {
         let mut w = World::new();
         let mut syms = SymbolTable::new();
 
-        let ambient = syms.add("ambient");
         let operation = syms.insert("operation");
         let check = syms.insert("check");
         let read = syms.add("read");

--- a/src/datalog/symbol.rs
+++ b/src/datalog/symbol.rs
@@ -1,7 +1,7 @@
 //! Symbol table implementation
 use chrono::{DateTime, NaiveDateTime, Utc};
 
-pub type Symbol = u64;
+pub type SymbolIndex = u64;
 use super::{Check, Fact, Predicate, Rule, World, ID};
 
 #[derive(Clone, Debug, PartialEq, Default)]
@@ -14,7 +14,7 @@ impl SymbolTable {
         SymbolTable::default()
     }
 
-    pub fn insert(&mut self, s: &str) -> Symbol {
+    pub fn insert(&mut self, s: &str) -> SymbolIndex {
         match self.symbols.iter().position(|sym| sym.as_str() == s) {
             Some(index) => index as u64,
             None => {
@@ -29,22 +29,22 @@ impl SymbolTable {
         ID::Str(id)
     }
 
-    pub fn get(&self, s: &str) -> Option<Symbol> {
+    pub fn get(&self, s: &str) -> Option<SymbolIndex> {
         self.symbols
             .iter()
             .position(|sym| sym.as_str() == s)
-            .map(|i| i as u64)
+            .map(|i| i as SymbolIndex)
     }
 
-    pub fn get_s(&self, s: Symbol) -> Option<&str> {
-        self.symbols.get(s as usize).map(|s| s.as_str())
+    pub fn get_symbol(&self, i: SymbolIndex) -> Option<&str> {
+        self.symbols.get(i as usize).map(|s| s.as_str())
     }
 
-    pub fn print_symbol(&self, s: Symbol) -> String {
+    pub fn print_symbol(&self, i: SymbolIndex) -> String {
         self.symbols
-            .get(s as usize)
+            .get(i as usize)
             .map(|s| s.to_string())
-            .unwrap_or_else(|| format!("<{}?>", s))
+            .unwrap_or_else(|| format!("<{}?>", i))
     }
 
     pub fn print_world(&self, w: &World) -> String {

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -209,28 +209,11 @@ impl SerializedBiscuit {
         //FIXME: try batched signature verification
         let mut current_pub = root;
 
-        //FIXME: replace with SHA512 hashing
-        let mut to_verify = self.authority.data.to_vec();
-        to_verify.extend(&self.authority.next_key.to_bytes());
-        current_pub
-            .0
-            .verify_strict(&to_verify, &self.authority.signature)
-            .map_err(|s| s.to_string())
-            .map_err(error::Signature::InvalidSignature)
-            .map_err(error::Format::Signature)?;
-
+        crypto::verify_block_signature(&self.authority, &current_pub)?;
         current_pub = &self.authority.next_key;
 
         for block in &self.blocks {
-            //FIXME: replace with SHA512 hashing
-            let mut to_verify = block.data.to_vec();
-            to_verify.extend(&block.next_key.to_bytes());
-
-            let res = current_pub.0.verify_strict(&to_verify, &block.signature);
-            res.map_err(|s| s.to_string())
-                .map_err(error::Signature::InvalidSignature)
-                .map_err(error::Format::Signature)?;
-
+            crypto::verify_block_signature(&block, &current_pub)?;
             current_pub = &block.next_key;
         }
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -186,25 +186,22 @@ impl SerializedBiscuit {
                 error::Format::SerializationError(format!("serialization error: {:?}", e))
             })?;
 
-        let mut blocks = vec![];
-        blocks.extend(self.blocks.iter().cloned());
-
         let signature = crypto::sign(&keypair, next_keypair, &v)?;
 
-        let mut t = SerializedBiscuit {
-            root_key_id: self.root_key_id,
-            authority: self.authority.clone(),
-            blocks: self.blocks.clone(),
-            proof: TokenNext::Secret(next_keypair.private()),
-        };
-
-        t.blocks.push(crypto::Block {
+        // Add new block
+        let mut blocks = self.blocks.clone();
+        blocks.push(crypto::Block {
             data: v,
             next_key: next_keypair.public(),
             signature: signature,
         });
 
-        Ok(t)
+        Ok(SerializedBiscuit {
+            root_key_id: self.root_key_id,
+            authority: self.authority.clone(),
+            blocks: blocks.clone(),
+            proof: TokenNext::Secret(next_keypair.private()),
+        })
     }
 
     /// checks the signature on a deserialized token

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -174,10 +174,7 @@ impl SerializedBiscuit {
 
     /// adds a new block, serializes it and sign a new token
     pub fn append(&self, next_keypair: &KeyPair, block: &Block) -> Result<Self, error::Token> {
-        let keypair = match &self.proof {
-            TokenNext::Seal(_) => return Err(error::Token::Sealed),
-            TokenNext::Secret(private) => KeyPair::from(private.clone()),
-        };
+        let keypair = self.proof.keypair()?;
 
         let mut v = Vec::new();
         token_block_to_proto_block(block)
@@ -252,10 +249,7 @@ impl SerializedBiscuit {
     }
 
     pub fn seal(&self) -> Result<Self, error::Token> {
-        let keypair = match &self.proof {
-            TokenNext::Seal(_) => return Err(error::Token::Sealed),
-            TokenNext::Secret(private) => KeyPair::from(private.clone()),
-        };
+        let keypair = self.proof.keypair()?;
 
         //FIXME: replace with SHA512 hashing
         let mut to_sign = Vec::new();


### PR DESCRIPTION
- Rename `Symbol` by `SymbolIndex`
- Refactor `variables_set` into a `Rule` instance method
- Use `Rule::apply` in `Rule::find_match`
- Use `p.ids[index] = val.clone()` instead of uselessly store the value
- Rename `SymbolTable::get_s` by `SymbolTable::get_symbol`